### PR TITLE
only print the message if arm64

### DIFF
--- a/android.toolchain.cmake
+++ b/android.toolchain.cmake
@@ -1423,7 +1423,7 @@ endif() # version 4.6
 if( ANDROID_COMPILER_VERSION VERSION_EQUAL "4.9" )
  if( ANDROID_GOLD_LINKER AND ARM64_V8A )
   set( ANDROID_LINKER_FLAGS "${ANDROID_LINKER_FLAGS} -fuse-ld=gold" )
- else()
+ elseif(ARM64_V8A)
   message( WARNING "The default bfd linker from arm64 GCC 4.9 toolchain can fail with undefined reference error message. See https://github.com/android-ndk/ndk/issues/148
   On Linux and OS X host platform you can workaround this problem using gold linker (default).
   Rerun cmake with -DANDROID_GOLD_LINKER=ON option in case of problems.


### PR DESCRIPTION
Oops, seems I got ahead of myself here. The previous patch makes a lot of spam on non-arm64 targets :)
